### PR TITLE
Set GDK_BACKEND to 'x11' on systems running wayland

### DIFF
--- a/WinAppsLauncher.sh
+++ b/WinAppsLauncher.sh
@@ -52,6 +52,14 @@ declare -x WINAPPS_PATH="" # Generated programmatically following dependency che
 declare -x WAFLAVOR=""     # As specified within the WinApps configuration file.
 
 ### FUNCTIONS ###
+# Check 'x11'/'wayland' Display Server Protocol
+function check_dsp() {
+    if [[ -n "$XDG_SESSION_TYPE" && "$XDG_SESSION_TYPE" == "wayland" ]]; then
+        # Set GDK_BACKEND to 'x11' for 'yad' compatibility.
+        export GDK_BACKEND=x11
+    fi
+}
+
 # Check WinApps Configuration File Exists
 function check_config_exists() {
     if [[ ! -f "$CONFIG_FILE" ]]; then
@@ -179,7 +187,7 @@ function app_select() {
         local SORTED_APP_LIST=()
         local SORTED_APP_STRING=""
         local SELECTED_APP=""
-        
+
         # Store the paths of all files within the directory 'WINAPPS_PATH'.
         readarray -t ALL_FILES < <(find "$WINAPPS_PATH" -maxdepth 1 -type f)
 
@@ -493,7 +501,7 @@ function resume_windows() {
     if [[ "$WAFLAVOR" == "libvirt" ]]; then
         virsh resume "$VM_NAME" &>/dev/null &
         wait $!
-        echo -e "${DEBUG_TEXT}> RESUMED '${VM_NAME}'${RESET_TEXT}"        
+        echo -e "${DEBUG_TEXT}> RESUMED '${VM_NAME}'${RESET_TEXT}"
     elif [[ "$WAFLAVOR" == "podman" ]]; then
         podman-compose --file "$COMPOSE_FILE" unpause &>/dev/null &
         wait $!
@@ -635,6 +643,9 @@ function refresh_menu() {
 export -f refresh_menu
 
 ### SEQUENTIAL LOGIC ###
+# Check display server protocol.
+check_dsp
+
 # Check 'DISPLAY' variable.
 [ -n "$DISPLAY" ] || exit "$EC_DSPLY_UNSET"
 


### PR DESCRIPTION
Introduced function to automatically set environment variable 'GDK_BACKEND' to 'x11' on systems running wayland.

This solution was tested successfully by @redelacruz [here](https://github.com/winapps-org/WinApps-Launcher/issues/12#issuecomment-2380652827) and requested by @freechelmi [here](https://github.com/winapps-org/winapps/discussions/124#discussioncomment-10761129).

As my personal system runs x11 and not wayland, would someone running wayland mind testing this PR? @freechelmi @redelacruz

Thanks guys!