### PR TITLE
Stop triggering libvirt error message if libvirt is not the actual backend

### DIFF
--- a/WinApps-Launcher.sh
+++ b/WinApps-Launcher.sh
@@ -672,9 +672,11 @@ if ! command -v yad &> /dev/null; then
 fi
 
 # 'libvirt'
-if ! command -v virsh &> /dev/null; then
-    show_error_message "ERROR: 'libvirt' <u>NOT FOUND</u>.\nPlease ensure 'libvirt' is installed."
-    exit "$EC_MISSING_DEP"
+if [[ "$WAFLAVOR" == "libvirt" ]]; then
+    if ! command -v virsh &> /dev/null; then
+        show_error_message "ERROR: 'libvirt' <u>NOT FOUND</u>.\nPlease ensure 'libvirt' is installed."
+        exit "$EC_MISSING_DEP"
+    fi
 fi
 
 # 'winapps'


### PR DESCRIPTION
Fixes #18 
If WinApps is set to use a backend other than libvirt, then libvirt should not be a mandatory dependency to install WinApps Launcher.
