### PR TITLE
Fix: Export VM_NAME to subshells for libvirt actions

### DIFF
--- a/WinApps-Launcher.sh
+++ b/WinApps-Launcher.sh
@@ -91,6 +91,7 @@ function read_winapps_config_file() {
     else
         echo -e "${DEBUG_TEXT}> USING VM NAME '${VM_NAME}'${RESET_TEXT}"
     fi
+    export VM_NAME
 
     # Use the default WinApps flavor if a flavor was not specified.
     if [[ -z "$WAFLAVOR" ]]; then


### PR DESCRIPTION
VM_NAME wasn't exported, so menu actions running in subshells couldn't see it. This broke virsh for anyone using a custom VM name with the libvirt backend.

Exporting the variable makes it available to the subshells, fixing the issue. 


``` bash

ray@ray-X450CA:~/.local/bin/winapps-src/WinApps-Launcher$ ./WinApps-Launcher.sh
WORKING DIRECTORY: '/home/ray/.local/bin/winapps-src/WinApps-Launcher'
> USING VM NAME 'win10'
> USING BACKEND 'libvirt'
* VM STATE: OFF
> STARTED ''
* VM STATE: error: Failed to get option domain: Option argument is empty
> STARTED ''
* VM STATE: error: Failed to get option domain: Option argument is empty
^C> EXIT

ray@ray-X450CA:~/.local/bin/winapps-src/WinApps-Launcher$ ./WinApps-Launcher.sh
WORKING DIRECTORY: '/home/ray/.local/bin/winapps-src/WinApps-Launcher'
> USING VM NAME 'win10'
> USING BACKEND 'libvirt'
* VM STATE: OFF
> STARTED 'win10'
* VM STATE: ON
> POWERED OFF 'win10'
* VM STATE: ON
* VM STATE: OFF
> REFRESHED MENU
> EXIT
ray@ray-X450CA:~/.local/bin/winapps-src/WinApps-Launcher$ 

```


these are the live terminal outputs form which i caught this bug.