### PR TITLE
Inject local bin into PATH for graphical launchers

### DIFF
--- a/winapps-launcher.sh
+++ b/winapps-launcher.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+export PATH="$HOME/.local/bin:$PATH" 
 ### GLOBAL CONSTANTS ###
 # ANSI Escape Sequences
 declare -rx ERROR_TEXT="\033[1;31m"

--- a/winapps-launcher.sh
+++ b/winapps-launcher.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export PATH="$HOME/.local/bin:$PATH" 
+[[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && export PATH="$PATH:$HOME/.local/bin" 
 ### GLOBAL CONSTANTS ###
 # ANSI Escape Sequences
 declare -rx ERROR_TEXT="\033[1;31m"


### PR DESCRIPTION
### Problem
Graphical launchers, desktop environments (like XFCE), and `.desktop` files execute scripts in non-interactive shell environments. As a result, they bypass interactive user configuration files (such as `~/.bashrc` or `~/.zshrc`) where local binary paths are typically defined. On distributions like Arch Linux, where local user binary paths (`~/.local/bin`) are not globally injected into graphical sessions by default, the launcher fails silently because it cannot resolve the host-side `winapps` binaries.

### Solution
This PR explicitly injects and exports `$HOME/.local/bin` at the start of `winapps-launcher.sh` to ensure the launcher can successfully bridge this environment gap.

### Safety & Compatibility
- **Process Isolation:** The path modification is strictly scoped to this script's execution thread and its child processes; it will not bleed into or alter the global host environment.
- **System-Wide Installs:** Because it utilizes standard POSIX path concatenation, it maintains total compatibility with system-wide installations (e.g., `/usr/bin/` or `/usr/local/bin/`).
- **Virtualized Backends:** The change is entirely host-side and has zero impact on backend isolation for Docker, Podman, or Libvirt configurations.
