### PR TITLE
Remove Arch linux title

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Feel free to fork, submit pull requests, open issues and promote this project to
 ## Dependencies
 You should already have most required dependencies after installing WinApps, but `yad` may be missing.
 
-### Arch / Debian / Ubuntu / Linux Mint / Zorin OS
+### Debian / Ubuntu / Linux Mint / Zorin OS
 ```bash
 sudo apt install yad
 ```


### PR DESCRIPTION
The command below is for the apt package manager and is not meant for arch linux. I misread the title and thought it was listing which distributions are supported, apologies.